### PR TITLE
Fix lint action YAML indentation

### DIFF
--- a/.github/workflows/lint-and-deploy.yml
+++ b/.github/workflows/lint-and-deploy.yml
@@ -35,8 +35,8 @@ jobs:
         run: bundle exec jekyll build
 
       - name: ✅ Lint HTML output
-      run: |
-         htmlproofer ./_site \
+        run: |
+          htmlproofer ./_site \
             --assume-extension \
             --check-html \
             --disable-external || echo "::warning::HTMLProofer warnings"
@@ -60,4 +60,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
           publish_branch: gh-pages
----


### PR DESCRIPTION
## Summary
- fix indentation for the HTML lint step in the workflow
- remove stray YAML document terminator

## Testing
- `pip install --user yamllint` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6859a611d080832293ad99dd02df1313