### PR TITLE
Fix missing htmlproofer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source "https://rubygems.org"
 # Pin a stable Jekyll version compatible with GitHub Pages
 gem "jekyll", "~> 4.3.2"
 
+# Include html-proofer to enable HTML validation
+gem "html-proofer"
+
 # Optional: Enable GitHub Pages-style compatibility (uncomment if needed)
 # gem "github-pages", group: :jekyll_plugins
 


### PR DESCRIPTION
## Summary
- add html-proofer gem to Gemfile

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 Forbidden)*
- `yamllint .` *(fails: command not found)*
- `stylelint '**/*.css'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b718f0208322bb596da28cf7df79