### PR TITLE
Add recent posts list to homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,4 +15,11 @@ title: JAKE9WI
     <li><p><a href="/recipes/pancake-premixed.html">Pancakes, Premixed</a></p></li>
 </ol>
 
+<h2>Recent Blog Posts</h2>
+<ul>
+{% for post in site.posts limit:5 %}
+    <li><a href="{{ post.url }}">{{ post.title }}</a> - {{ post.date | date: "%B %-d, %Y" }}</li>
+{% endfor %}
+</ul>
+
 </main>


### PR DESCRIPTION
## Summary
- make the homepage list the latest blog posts dynamically

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found)*
- `stylelint '**/*.css'` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685ae583572083229d668779788aaf72